### PR TITLE
Enable cross-building for Scala 2.11 and 2.12

### DIFF
--- a/constructr-coordination-redis/src/main/scala/com/github/everpeace/constructr/coordination/redis/RedisCoordination.scala
+++ b/constructr-coordination-redis/src/main/scala/com/github/everpeace/constructr/coordination/redis/RedisCoordination.scala
@@ -30,7 +30,7 @@ final class RedisCoordination(
     val clusterName: String,
     val system: ActorSystem
 ) extends Coordination {
-  private[this] implicit val _system: ActorRefFactory = system
+  private[this] implicit val _system: ActorSystem = system
   private[this] implicit val _ec: ExecutionContext = _system.dispatcher
 
   private[this] val redis = RedisClientFactory.fromConfig(system.settings.config)
@@ -114,7 +114,7 @@ final class RedisCoordination(
 }
 
 object RedisClientFactory {
-  def fromConfig(config: Config)(implicit af: ActorRefFactory): RedisClient = {
+  def fromConfig(config: Config)(implicit af: ActorSystem): RedisClient = {
     val host = Option(config.getString("constructr.coordination.host")).filter(_.trim.nonEmpty).getOrElse("")
     val port = config.getInt("constructr.coordination.port")
     require(host.nonEmpty, "\"constructr.coordination.redis.host\" must be given.")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -31,8 +31,8 @@ object Build extends AutoPlugin {
           <url>http://everpeace.github.io/</url>
         </developer>
       </developers>,
-    scalaVersion := Version.Scala,
-    crossScalaVersions := Vector(scalaVersion.value),
+    scalaVersion := Version.Scala.head,
+    crossScalaVersions := Version.Scala,
     scalacOptions ++= Vector(
       "-unchecked",
       "-deprecation",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,11 +1,11 @@
 import sbt._
 
 object Version {
-    final val Scala            = "2.11.8"
+    final val Scala            = Seq("2.11.8", "2.12.1")
     final val Constructr       = "0.17.0"
-    final val Rediscala        = "1.6.0"
+    final val Rediscala        = "1.8.0"
     final val Akka             = "2.5.0"
-    final val AkkaLog4j        = "1.1.3"
+    final val AkkaLog4j        = "1.4.0"
     final val Log4j            = "2.5"
     final val ScalaTest        = "3.0.0"
 }


### PR DESCRIPTION
Update dependencies versions to ones supporting Scala 2.12, modify the
code to accomodate for Rediscala API changes.